### PR TITLE
Update Payable getAccountBalance

### DIFF
--- a/src/Traits/Payable.php
+++ b/src/Traits/Payable.php
@@ -83,7 +83,7 @@ trait Payable
 
     public function getAccountBalance(): Balance
     {
-        return static::$stripe->balance->retrieve([
+        return static::$stripe->balance->retrieve([], [
             'stripe_account' => $this->getStripeAccountId(),
         ]);
     }


### PR DESCRIPTION
The current call is always returning this error
![image](https://github.com/simonhamp/laravel-stripe-connect/assets/98289378/9e995165-0806-4ba6-aac0-1cbbe2560652)

As stated on the HINT and also as I could verify locally passing an empty array would indeed solve the issue.