### PR TITLE
Update method to avoid clash with laravel cashier

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,10 +81,10 @@ Route::get('/connect', function () {
 })->middleware(['auth']);
 ```
 
-Once a user's Stripe account is all connected and active, you can start sending them payments:
+Once a user's Stripe account is all connected and active, you can start creating transfers:
 
 ```php
-auth()->user()->pay(10000, 'usd');
+auth()->user()->transfer(10000, 'usd');
 ```
 
 > [!NOTE]

--- a/src/Traits/Payable.php
+++ b/src/Traits/Payable.php
@@ -71,7 +71,7 @@ trait Payable
         return $link->url;
     }
 
-    public function pay($amount, $currency): Transfer
+    public function transfer($amount, $currency): Transfer
     {
         // TODO: capture this in the database, which may allow us to do a reversal later
         return static::$stripe->transfers->create([


### PR DESCRIPTION
Currently applications can use both stripe connect to split payment between users and there's use cases where the same users that will receive those transfers could also be subscribers of a subscription or can buy goods on the platform or website.

Because of this there's cases where we will want Users to be both payable and billable (using laravel Cashier)

In this specific case we could have method clash because Cashier currently implements the pay method in order to charge customers.

This PR aims to solve this method name clashing, also aligns the name with the conventional name that stripe uses, making it easier to use.

It also updates the Readme examples to avoid misusage


**This is a breaking change**